### PR TITLE
fix bug with overlong LDAP-results

### DIFF
--- a/etc/login.d/00_userinfo.sh
+++ b/etc/login.d/00_userinfo.sh
@@ -18,9 +18,26 @@ if [ -n "$ad_connected" ]; then
   [ -e "$userinfo" ] && rm -f "$userinfo"
 
   date > "$userinfo"
-
+  tmpuserinfo=`mktemp`
   # ad query
-  ldbsearch -k yes -H ldaps://$servername.$ad_domain "(&(samaccountname=$USER))" | tee "$userinfo"
+  ldbsearch -k yes -H ldaps://$servername.$ad_domain "(&(samaccountname=$USER))" | tee "$tmpuserinfo"
+  OLDIFS=$IFS
+  IFS=""  ## knock out field separator
+  printline=""
+  while read -r line; do
+      if [ "${line:0:1}" != " " ]; then
+	  echo $printline >> "$userinfo"
+	  printline=$line
+      else
+	  ## concat all LDAP overfull lines
+	  printline=$printline${line:1}
+      fi
+  done < "$tmpuserinfo"
+  echo $printline >> "$userinfo" ## print last buffer
+  echo $line >> "$userinfo" ## print last buffer, if file does not end with '\n'
+  IFS=$OLDIFS ## restore Field separator
+  rm -f $tmpuserinfo
+  
   chown "$USER" "$userinfo"
   chmod 400 "$userinfo"
 


### PR DESCRIPTION
also: , date will now be at the start of the file (was overwritten)