### PR TITLE
Minor Changes for cifs mount and default shell

### DIFF
--- a/templates/pam_mount.conf.xml
+++ b/templates/pam_mount.conf.xml
@@ -7,8 +7,8 @@
 <!DOCTYPE pam_mount SYSTEM "pam_mount.conf.xml.dtd">
 <pam_mount>
     <debug enable="1" />
-    <volume user="*" fstype="cifs" server="@@servername@@.@@domainname@@" path="default-school" mountpoint="/srv/samba/schools/default-school" options="sec=ntlmssp,nodev,nosuid,mfsymlinks,nobrl,vers=1.0" />
-    <volume user="*" fstype="cifs" server="@@servername@@.@@domainname@@" path="sysvol" mountpoint="/var/lib/samba/sysvol" options="sec=ntlmssp,nodev,nosuid,mfsymlinks,nobrl,vers=1.0" />
+    <volume user="*" fstype="cifs" server="@@servername@@.@@domainname@@" path="default-school" mountpoint="/srv/samba/schools/default-school" options="sec=ntlmssp,nodev,nosuid,mfsymlinks,nobrl,vers=3.0" />
+    <volume user="*" fstype="cifs" server="@@servername@@.@@domainname@@" path="sysvol" mountpoint="/var/lib/samba/sysvol" options="sec=ntlmssp,nodev,nosuid,mfsymlinks,nobrl,vers=3.0" />
     <mntoptions allow="nosuid,nodev,loop,encryption,fsck,nonempty,allow_root,allow_other" />
     <mntoptions require="nosuid,nodev" />
     <logout wait="1000" hup="0" term="1" kill="1" />

--- a/templates/sssd.conf
+++ b/templates/sssd.conf
@@ -12,6 +12,7 @@ domains = @@realm@@
 [domain/@@realm@@]
 id_provider = ad
 access_provider = ad
+default_shell = /bin/bash
 
 # optional but very useful for laptops that are sometimes offline
 cache_credentials = true


### PR DESCRIPTION
Hi Tobias,

I added two minor changes, using cifs version >=2.0 allow the client to see the current disk usage.

In addition I changed the default_shell which wasn't defined and falled back to /bin/dash.